### PR TITLE
partial fix of generating pdf output from fit result

### DIFF
--- a/templates/07_load_fitresult.py
+++ b/templates/07_load_fitresult.py
@@ -1,0 +1,34 @@
+"""Load a fit result from a a directory where a fit result was saved with save_fitresult"""
+from pyhdx.fileIO import load_fitresult
+from pathlib import Path
+import numpy as np
+import matplotlib.pyplot as plt
+
+
+current_dir = Path().cwd()
+fit_result = load_fitresult(current_dir / 'output' / 'SecB_fit')
+
+
+time = np.logspace(-3, 2, num=100)
+
+d_calc = fit_result(time)
+d_exp = fit_result.data_obj.d_exp
+
+i = 20  # index of the protein to view
+
+fit_result.losses[['total_loss', 'mse_loss', 'reg_loss']].plot()
+
+fig, ax = plt.subplots()
+ax.scatter(fit_result.data_obj.timepoints, d_exp[i], color='k')
+ax.plot(time, d_calc[i], color='r')
+ax.set_xscale('log')
+ax.set_xlabel('Time (min)')
+ax.set_ylabel('Corrected D-uptake (Da)')
+ax.set_title(f'Peptide index: {i}')
+
+fig, ax = plt.subplots()
+ax.set_aspect(2)
+ax.scatter(fit_result.output.index, fit_result.output['deltaG']*1e-3)
+ax.set_xlabel('Residue number')
+ax.set_ylabel('ΔG (kJ/mol)')
+plt.show()

--- a/templates/08_fit_report_pdf.py
+++ b/templates/08_fit_report_pdf.py
@@ -1,0 +1,13 @@
+"""Generate a pdf output with all peptide fits. Requires pdflatex"""
+from pyhdx.output import Output, Report
+from pyhdx.fileIO import load_fitresult
+from pathlib import Path
+
+current_dir = Path().cwd()
+fit_result = load_fitresult(current_dir / 'output' / 'SecB_fit')
+
+output = Output(fit_result)
+
+report = Report(output)
+report.add_peptide_figures()
+report.generate_pdf(current_dir / 'output' / 'SecB_fit_report')


### PR DESCRIPTION
This PR fixes generating pdfs with all peptide time vs d-uptake curves + fitted result.

Usage:

```python
output = Output(fit_result)

report = Report(output)
report.add_peptide_figures()
report.generate_pdf('out_name')
```
