### PR TITLE
Allow CUDA and float dtype

### DIFF
--- a/pyhdx/__init__.py
+++ b/pyhdx/__init__.py
@@ -1,8 +1,12 @@
 from .models import PeptideMasterTable, PeptideMeasurements, HDXMeasurement, Coverage, HDXMeasurementSet
 from .fileIO import read_dynamx
 from .fitting_torch import TorchSingleFitResult, TorchBatchFitResult
-from .output import Output, Report
 from ._version import get_versions
+
+try:
+    from .output import Output, Report
+except ModuleNotFoundError:
+    pass
 
 
 __version__ = get_versions()['version']

--- a/pyhdx/cli.py
+++ b/pyhdx/cli.py
@@ -1,7 +1,7 @@
 import argparse
 from ipaddress import ip_address
 from pyhdx.web import serve
-from pyhdx.config import ConfigurationSettings
+from pyhdx.config import cfg
 from pyhdx.local_cluster import verify_cluster, default_cluster
 
 
@@ -14,8 +14,6 @@ def main():
     parser.add_argument('serve', help="Runs PyHDX Dashboard")
     parser.add_argument('--scheduler_address', help="Run with local cluster <ip>:<port>")
     args = parser.parse_args()
-
-    cfg = ConfigurationSettings()
 
     if args.scheduler_address:
         ip, port = args.scheduler_address.split(':')

--- a/pyhdx/config.ini
+++ b/pyhdx/config.ini
@@ -1,3 +1,7 @@
 [cluster]
 scheduler_address = 127.0.0.1:52123
 n_workers = 10
+
+[fitting]
+dtype = float64
+device = cpu

--- a/pyhdx/config.py
+++ b/pyhdx/config.py
@@ -91,6 +91,21 @@ class ConfigurationSettings(metaclass=Singleton):
         with open(pth, 'w') as config_file:
             self._config.write(config_file)
 
+    @property
+    def TORCH_DTYPE(self):
+        dtype = self.get('fitting', 'dtype')
+        if dtype in ['float64', 'double']:
+            return torch.float64
+        elif dtype in ['float32', 'float']:
+            return torch.float32
+        else:
+            raise ValueError(f'Unsupported data type: {dtype}')
+
+    @property
+    def TORCH_DEVICE(self):
+        device = self.get('fitting', 'device')
+        return torch.device(device)
+
 
 def valid_config():
     """Checks if the current config file in the user home directory is a valid config
@@ -117,3 +132,5 @@ current_dir = Path(__file__).parent
 config_file_path = config_dir / 'config.ini'
 if not valid_config():
     reset_config()
+
+cfg = ConfigurationSettings()

--- a/pyhdx/config.py
+++ b/pyhdx/config.py
@@ -1,8 +1,13 @@
 import configparser
 from pathlib import Path
-from pyhdx import __version__
+from pyhdx._version import get_versions
 from packaging import version
+import torch
 import warnings
+
+
+__version__ = get_versions()['version']
+del get_versions
 
 
 def read_config(path):

--- a/pyhdx/fitting.py
+++ b/pyhdx/fitting.py
@@ -10,9 +10,10 @@ from symfit.core.minimizers import DifferentialEvolution, Powell
 from tqdm import trange
 
 from pyhdx.fit_models import SingleKineticModel, TwoComponentAssociationModel, TwoComponentDissociationModel
-from pyhdx.fitting_torch import DeltaGFit, TorchSingleFitResult, TorchBatchFitResult, TORCH_DTYPE, TORCH_DEVICE
-from pyhdx.models import Protein
+from pyhdx.fitting_torch import DeltaGFit, TorchSingleFitResult, TorchBatchFitResult
 from pyhdx.support import temporary_seed
+from pyhdx.models import Protein
+from pyhdx.config import cfg
 
 EmptyResult = namedtuple('EmptyResult', ['chi_squared', 'params'])
 er = EmptyResult(np.nan, {k: np.nan for k in ['tau1', 'tau2', 'r']})
@@ -451,7 +452,7 @@ def fit_gibbs_global(hdxm, initial_guess, r1=R1, epochs=EPOCHS, patience=PATIENC
     assert len(initial_guess) == hdxm.Nr, "Invalid length of initial guesses"
 
     dtype = torch.float64
-    deltaG_par = torch.nn.Parameter(torch.tensor(initial_guess, dtype=TORCH_DTYPE, device=TORCH_DEVICE).unsqueeze(-1))  #reshape (nr, 1)
+    deltaG_par = torch.nn.Parameter(torch.tensor(initial_guess, dtype=cfg.TORCH_DTYPE, device=cfg.TORCH_DEVICE).unsqueeze(-1))  #reshape (nr, 1)
 
     model = DeltaGFit(deltaG_par)
     criterion = torch.nn.MSELoss(reduction='mean')
@@ -580,7 +581,7 @@ def _batch_fit(hdx_set, initial_guess, reg_func, fit_kwargs, optimizer_kwargs):
 
     assert initial_guess.shape == (hdx_set.Ns, hdx_set.Nr), "Invalid shape of initial guesses"
 
-    deltaG_par = torch.nn.Parameter(torch.tensor(initial_guess, dtype=TORCH_DTYPE, device=TORCH_DEVICE).reshape(hdx_set.Ns, hdx_set.Nr, 1))
+    deltaG_par = torch.nn.Parameter(torch.tensor(initial_guess, dtype=cfg.TORCH_DTYPE, device=cfg.TORCH_DEVICE).reshape(hdx_set.Ns, hdx_set.Nr, 1))
 
     model = DeltaGFit(deltaG_par)
     criterion = torch.nn.MSELoss(reduction='mean')

--- a/pyhdx/fitting_torch.py
+++ b/pyhdx/fitting_torch.py
@@ -8,9 +8,10 @@ from scipy import constants, linalg
 
 from pyhdx.fileIO import dataframe_to_file
 from pyhdx.models import Protein
+from pyhdx.config import cfg
 
-TORCH_DTYPE = t.double
-TORCH_DEVICE = t.device('cpu')
+# TORCH_DTYPE = t.double
+# TORCH_DEVICE = t.device('cpu')
 
 class DeltaGFit(nn.Module):
     def __init__(self, deltaG):
@@ -46,11 +47,12 @@ def estimate_errors(hdxm, deltaG):
     -------
 
     """
+    dtype = t.float64
     joined = pd.concat([deltaG, hdxm.coverage['exchanges']], axis=1, keys=['dG', 'ex'])
     dG = joined.query('ex==True')['dG']
-    deltaG = t.tensor(dG.to_numpy(), dtype=TORCH_DTYPE)
+    deltaG = t.tensor(dG.to_numpy(), dtype=dtype)
 
-    tensors = {k: v.cpu() for k, v in hdxm.get_tensors(exchanges=True).items()}
+    tensors = {k: v.cpu() for k, v in hdxm.get_tensors(exchanges=True, dtype=dtype).items()}
 
     def hes_loss(deltaG_input):
         criterion = t.nn.MSELoss(reduction='sum')

--- a/pyhdx/local_cluster.py
+++ b/pyhdx/local_cluster.py
@@ -1,9 +1,7 @@
 from dask.distributed import LocalCluster, Client
 import time
-from pyhdx.config import ConfigurationSettings
+from pyhdx.config import cfg
 import argparse
-
-cfg = ConfigurationSettings()
 
 def default_client(timeout='2s'):
     """Return Dask client at scheduler adress as defined by the global config"""

--- a/pyhdx/models.py
+++ b/pyhdx/models.py
@@ -12,6 +12,7 @@ import pyhdx
 from pyhdx.alignment import align_dataframes
 from pyhdx.fileIO import dataframe_to_file
 from pyhdx.support import reduce_inter, fields_view
+from pyhdx.config import cfg
 
 
 def protein_wrapper(func, *args, **kwargs):
@@ -748,7 +749,7 @@ class HDXMeasurement(object):
         df.columns.name = 'exposure'
         return df
 
-    def get_tensors(self, exchanges=False):
+    def get_tensors(self, exchanges=False, dtype=None):
         """
         Returns a dictionary of tensor variables for fitting to Linderstrøm-Lang kinetics.
 
@@ -784,8 +785,8 @@ class HDXMeasurement(object):
         else:
             bools = np.ones(self.Nr, dtype=bool)
 
-        dtype = pyhdx.fitting_torch.TORCH_DTYPE
-        device = pyhdx.fitting_torch.TORCH_DEVICE
+        dtype = dtype or cfg.TORCH_DTYPE
+        device = cfg.TORCH_DEVICE
 
         tensors = {
             'temperature': torch.tensor([self.temperature], dtype=dtype, device=device).unsqueeze(-1),
@@ -1130,7 +1131,7 @@ class HDXMeasurementSet(object):
 
         self.aligned_indices = df.to_numpy(dtype=int).T
 
-    def get_tensors(self):
+    def get_tensors(self, dtype=None):
         #todo create correct shapes as per table X for all
         temperature = np.array([kf.temperature for kf in self.hdxm_list])
 
@@ -1142,8 +1143,8 @@ class HDXMeasurementSet(object):
         k_int = np.zeros((self.Ns, self.Nr))
         k_int[self.masks['sr']] = k_int_values
 
-        dtype = pyhdx.fitting_torch.TORCH_DTYPE
-        device = pyhdx.fitting_torch.TORCH_DEVICE
+        dtype = dtype or cfg.TORCH_DTYPE
+        device = cfg.TORCH_DEVICE
 
         tensors = {
             'temperature': torch.tensor(temperature, dtype=dtype, device=device).reshape(self.Ns, 1, 1),

--- a/pyhdx/web/apps.py
+++ b/pyhdx/web/apps.py
@@ -15,7 +15,7 @@ from pyhdx.web.filters import UniqueValuesFilter, MultiIndexSelectFilter
 import logging
 import panel as pn
 from pyhdx.web.log import logger
-from pyhdx.config import ConfigurationSettings
+from pyhdx.config import cfg
 from pyhdx.local_cluster import default_client
 
 from pathlib import Path
@@ -27,7 +27,6 @@ DEBUG = True
 current_dir = Path(__file__).parent
 data_dir = current_dir.parent.parent / 'tests' / 'test_data'
 global_opts = {'show_grid': True}
-cfg = ConfigurationSettings()
 
 @logger('pyhdx')
 def main_app(client='default'):

--- a/pyhdx/web/serve.py
+++ b/pyhdx/web/serve.py
@@ -4,7 +4,7 @@ from pyhdx.web.base import STATIC_DIR
 import numpy as np
 import torch
 
-from pyhdx.config import ConfigurationSettings
+from pyhdx.config import cfg
 from pyhdx.local_cluster import verify_cluster
 
 import logging
@@ -24,7 +24,7 @@ def run_main():
     np.random.seed(43)
     torch.manual_seed(43)
 
-    scheduler_address = ConfigurationSettings().get('cluster', 'scheduler_address')
+    scheduler_address = cfg.get('cluster', 'scheduler_address')
     if not verify_cluster(scheduler_address):
         print(f"No valid Dask scheduler found at specified address: '{scheduler_address}'")
         return


### PR DESCRIPTION
Users can now execute fitting on cuda-enabled devices by settings this in the config:

```python
from pyhdx.config import cfg
cfg.set('fitting', 'device', 'cude')
```

And dtypes:

```python
from pyhdx.config import cfg
cfg.set('fitting', 'dtype', 'float32')
```

Supported dtypes are `float32` and `float64`

Switching to cuda is only economical for (very) large datasets (Total ~5000 residues, exact tradeoff point not tested and depends on specific hardware use)
