### PR TITLE
fix: reset_index is not an argument

### DIFF
--- a/pyhdx/process.py
+++ b/pyhdx/process.py
@@ -71,7 +71,7 @@ def apply_control(
         nd_control["uptake_sd"] = 0
 
     intersected = dataframe_intersection(
-        [experiment, fd_control, nd_control], ["start", "stop"], reset_index=False
+        [experiment, fd_control, nd_control], ["start", "stop"]
     )
 
     # select out uptake (u; experiment), FD uptake (f) and ND uptake (n), as well as their sd's


### PR DESCRIPTION
`apply_control` function in [this](https://pyhdx.readthedocs.io/en/latest/examples/01_basic_usage/#:~:text=peptides_control%20%3D-,apply_control,-(peptides%2C)) example, I realised that `dataframe_intersection` in `pyhdx.support` doesn't have `reset_index` as argument.